### PR TITLE
Put quotes around reserved keys

### DIFF
--- a/lib/jsurl.js
+++ b/lib/jsurl.js
@@ -64,9 +64,9 @@
 	};
 
 	var reserved = {
-		true: true,
-		false: false,
-		null: null
+		"true": true,
+		"false": false,
+		"null": null
 	};
 
 	exports.parse = function(s) {


### PR DESCRIPTION
Unescaped reserved object keys were causing some issues in Webkit whereby the library would fail to be parsed by the browser. This was only the case in certain situations which I never fully debugged, but explicitly casting the keys as strings solved the problem.