### PR TITLE
RFC: Shorter encoding for true/false/null and some chars

### DIFF
--- a/lib/jsurl.js
+++ b/lib/jsurl.js
@@ -22,13 +22,18 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  * OTHER DEALINGS IN THE SOFTWARE.
  */
-// 
+//
 (function(exports) {
 	"use strict";
 	exports.stringify = function stringify(v) {
 		function encode(s) {
-			return !/[^\w-.]/.test(s) ? s : s.replace(/[^\w-.]/g, function(ch) {
+			return !/[^\w-.'(]/.test(s) ? s : s.replace(/[^\w-.'(]/g, function(ch) {
 				if (ch === '$') return '!';
+
+				// TODO: Make * a proper escape, mapping *[^a-f0-9] to common chars
+				// mapping can use [g-zA..Z]_()-.'~!
+				// "ghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+				// " ~!@#%^&*)_+`=[]{},<>/\|"
 				ch = ch.charCodeAt(0);
 				// thanks to Douglas Crockford for the negative slice trick
 				return ch < 0x100 ? '*' + ('00' + ch.toString(16)).slice(-2) : '**' + ('0000' + ch.toString(16)).slice(-4);
@@ -37,16 +42,16 @@
 
 		switch (typeof v) {
 			case 'number':
-				return isFinite(v) ? '~' + v : '~null';
+				return isFinite(v) ? '~' + v : '~!2';
 			case 'boolean':
-				return '~' + v;
+				return '~!' + (v ? 1 : 0);
 			case 'string':
 				return "~'" + encode(v);
 			case 'object':
-				if (!v) return '~null';
+				if (!v) return '~!2';
 				if (Array.isArray(v)) {
 					return '~(' + (v.map(function(elt) {
-						return stringify(elt) || '~null';
+						return stringify(elt) || '~!2';
 					}).join('') || '~') + ')';
 				} else {
 					return '~(' + Object.keys(v).map(function(key) {
@@ -66,7 +71,10 @@
 	var reserved = {
 		true: true,
 		false: false,
-		null: null
+		null: null,
+		'!0': false,
+		'!1': true,
+		'!2': null
 	};
 
 	exports.parse = function(s) {

--- a/test/common/jsurlTest.js
+++ b/test/common/jsurlTest.js
@@ -14,25 +14,25 @@ test('basic values', 26, function() {
 	t(function() {
 		foo();
 	}, undefined);
-	t(null, "~null");
-	t(false, "~false");
-	t(true, "~true");
+	t(null, "~!2");
+	t(false, "~!0");
+	t(true, "~!1");
 	t(0, "~0");
 	t(1, "~1");
 	t(-1.5, "~-1.5");
 	t("hello world\u203c", "~'hello*20world**203c");
-	t(" !\"#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~", "~'*20*21*22*23!*25*26*27*28*29*2a*2b*2c-.*2f09*3a*3b*3c*3d*3e*3f*40AZ*5b*5c*5d*5e_*60az*7b*7c*7d*7e");
+	t(" !\"#$%&'()*+,-./09:;<=>?@AZ[\\]^_`az{|}~", "~'*20*21*22*23!*25*26'(*29*2a*2b*2c-.*2f09*3a*3b*3c*3d*3e*3f*40AZ*5b*5c*5d*5e_*60az*7b*7c*7d*7e");
 	// JSON.stringify converts special numeric values to null
-	t(NaN, "~null");
-	t(Infinity, "~null");
-	t(-Infinity, "~null");
+	t(NaN, "~!2");
+	t(Infinity, "~!2");
+	t(-Infinity, "~!2");
 });
 test('arrays', 4, function() {
 	t([], "~(~)");
 	t([undefined, function() {
 		foo();
 	},
-	null, false, 0, "hello world\u203c"], "~(~null~null~null~false~0~'hello*20world**203c)");
+	null, false, 0, "hello world\u203c"], "~(~!2~!2~!2~!0~0~'hello*20world**203c)");
 });
 test('objects', 4, function() {
 	t({}, "~()");
@@ -45,7 +45,7 @@ test('objects', 4, function() {
 		d: false,
 		e: 0,
 		f: "hello world\u203c"
-	}, "~(c~null~d~false~e~0~f~'hello*20world**203c)");
+	}, "~(c~!2~d~!0~e~0~f~'hello*20world**203c)");
 });
 test('mix', 2, function() {
 	t({


### PR DESCRIPTION
Some backwards compatible changes.

Is this acceptable? Other optimizations would be using the * for more characters, to use only 2 chars instead of 3 for punctuation, and allowing the definition of a dictionary (to be provided at decode), so common keys are replaced with e.g. "![0-9a-zA-Z]". This last could even be done inside strings with substring matches.