### PR TITLE
Move examples order to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ JSON:
 {"name":"John Doe","age":42,"children":["Mary","Bill"]}
 ```
 
-JSURL:
-
-``` jsurl
-~(name~'John*20Doe~age~42~children~(~'Mary~'Bill))
-```
-
 JSON + URL encoding:
 
 ```
 %7B%22name%22%3A%22John%20Doe%22%2C%22age%22%3A42%2C%22children%22%3A%5B%22Mary%22%2C%22Bill%22%5D%7D
+```
+
+JSURL:
+
+``` jsurl
+~(name~'John*20Doe~age~42~children~(~'Mary~'Bill))
 ```
 
 ## API


### PR DESCRIPTION
I just wanted to create a new issue and ask you why there is an example of an encoded JSURL in the `README.md` but then I realized you put encoded JSON there so it makes sense now. I think we should adjust the order to avoid confusing here.

I don't think we need a fourth example to show you an encoded JSURL because it would be the same as an unencoded JSURL.