### PR TITLE
IE 6-8 compat

### DIFF
--- a/lib/jsurl.js
+++ b/lib/jsurl.js
@@ -35,7 +35,7 @@
 			});
 		}
 
-		var tmpAry = [];
+		var tmpAry;
 
 		switch (typeof v) {
 			case 'number':
@@ -46,11 +46,12 @@
 				return "~'" + encode(v);
 			case 'object':
 				if (!v) return '~null';
+
+				tmpAry = [];
+
 				if (Array.isArray(v)) {
 					for (var i = 0; i < v.length; i++) {
-						if (i in v) {
-							tmpAry[i] = stringify(v[i]) || '~null';
-						}
+						tmpAry[i] = stringify(v[i]) || '~null';
 					}
 
 					return '~(' + (tmpAry.join('') || '~') + ')';
@@ -66,7 +67,7 @@
 						}
 					}
 
-					return '~(' + tmpAry.sort().join('~') + ')';
+					return '~(' + tmpAry.join('~') + ')';
 				}
 			default:
 				// function, undefined

--- a/lib/jsurl.js
+++ b/lib/jsurl.js
@@ -22,7 +22,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
  * OTHER DEALINGS IN THE SOFTWARE.
  */
-// 
+//
 (function(exports) {
 	"use strict";
 	exports.stringify = function stringify(v) {
@@ -35,6 +35,8 @@
 			});
 		}
 
+		var tmpAry = [];
+
 		switch (typeof v) {
 			case 'number':
 				return isFinite(v) ? '~' + v : '~null';
@@ -45,17 +47,26 @@
 			case 'object':
 				if (!v) return '~null';
 				if (Array.isArray(v)) {
-					return '~(' + (v.map(function(elt) {
-						return stringify(elt) || '~null';
-					}).join('') || '~') + ')';
+					for (var i = 0; i < v.length; i++) {
+						if (i in v) {
+							tmpAry[i] = self.jsUrl(v[i]) || "~null";
+						}
+					}
+
+					return "~(" + (tmpAry.join("") || "~") + ")";
 				} else {
-					return '~(' + Object.keys(v).map(function(key) {
-						var val = stringify(v[key]);
-						// skip undefined and functions
-						return val && (encode(key) + val);
-					}).filter(function(str) {
-						return str;
-					}).join('~') + ')';
+					for (var key in v) {
+						if (v.hasOwnProperty(key)) {
+							var val = self.jsUrl(v[key]);
+							// skip undefined and functions
+
+							if (val) {
+								tmpAry.push(encode(key) + val);
+							}
+						}
+					}
+
+					return "~(" + tmpAry.sort().join("~") + ")";
 				}
 			default:
 				// function, undefined
@@ -75,18 +86,18 @@
 			len = s.length;
 
 		function eat(expected) {
-			if (s[i] !== expected) throw new Error("bad JSURL syntax: expected " + expected + ", got " + (s && s[i]));
+			if (s.charAt(i) !== expected) throw new Error("bad JSURL syntax: expected " + expected + ", got " + (s && s.charAt(i)));
 			i++;
 		}
 
 		function decode() {
 			var beg = i,
 				ch, r = "";
-			while (i < len && (ch = s[i]) !== '~' && ch !== ')') {
+			while (i < len && (ch = s.charAt(i)) !== '~' && ch !== ')') {
 				switch (ch) {
 					case '*':
 						if (beg < i) r += s.substring(beg, i);
-						if (s[i + 1] === '*') r += String.fromCharCode(parseInt(s.substring(i + 2, i + 6), 16)), beg = (i += 6);
+						if (s.charAt(i + 1) === '*') r += String.fromCharCode(parseInt(s.substring(i + 2, i + 6), 16)), beg = (i += 6);
 						else r += String.fromCharCode(parseInt(s.substring(i + 1, i + 3), 16)), beg = (i += 3);
 						break;
 					case '!':
@@ -103,24 +114,24 @@
 		return (function parseOne() {
 			var result, ch, beg;
 			eat('~');
-			switch (ch = s[i]) {
+			switch (ch = s.charAt(i)) {
 				case '(':
 					i++;
-					if (s[i] === '~') {
+					if (s.charAt(i) === '~') {
 						result = [];
-						if (s[i + 1] === ')') i++;
+						if (s.charAt(i + 1) === ')') i++;
 						else {
 							do {
 								result.push(parseOne());
-							} while (s[i] === '~');
+							} while (s.charAt(i) === '~');
 						}
 					} else {
 						result = {};
-						if (s[i] !== ')') {
+						if (s.charAt(i) !== ')') {
 							do {
 								var key = decode();
 								result[key] = parseOne();
-							} while (s[i] === '~' && ++i);
+							} while (s.charAt(i) === '~' && ++i);
 						}
 					}
 					eat(')');
@@ -131,7 +142,7 @@
 					break;
 				default:
 					beg = i++;
-					while (i < len && /[^)~]/.test(s[i]))
+					while (i < len && /[^)~]/.test(s.charAt(i)))
 					i++;
 					var sub = s.substring(beg, i);
 					if (/[\d\-]/.test(ch)) {


### PR DESCRIPTION
[`Array.map()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) and [`Array.filter()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter) are not available in IE <= 8.

This change replaces those functions with simple iterators to accomplish the same result.